### PR TITLE
[블록 수정] 자료구조 - 블록의 위키트리 수정 요청 (#30)

### DIFF
--- a/src/data/datastructure.js
+++ b/src/data/datastructure.js
@@ -9,7 +9,7 @@ export const datastructureCollection = {
 					description: {
 						text: "배열은 번호(인덱스)와 번호에 대응하는 데이터들로 이루어진 자료 구조를 나타낸다.",
 						links: [
-							["배열 - 위키트리", "https://ko.wikipedia.org/wiki/%EB%B0%B0%EC%97%B4"],
+							["배열 - 위키백과", "https://ko.wikipedia.org/wiki/%EB%B0%B0%EC%97%B4"],
 							["배열 기초 YOUTUBE", "https://youtu.be/NFETSCJON2M"],
 						]
 					}
@@ -19,7 +19,7 @@ export const datastructureCollection = {
 					description: {
 						text: "연결 리스트(linked list)는 각 노드가 데이터와 포인터를 가지고 한 줄로 연결되어 있는 방식으로 데이터를 저장하는 자료 구조이다.",
 						links: [
-							["연결 리스트 - 위키트리", "https://ko.wikipedia.org/wiki/%EC%97%B0%EA%B2%B0_%EB%A6%AC%EC%8A%A4%ED%8A%B8"],
+							["연결 리스트 - 위키백과", "https://ko.wikipedia.org/wiki/%EC%97%B0%EA%B2%B0_%EB%A6%AC%EC%8A%A4%ED%8A%B8"],
 						]
 					},
 					skills: [
@@ -28,7 +28,7 @@ export const datastructureCollection = {
 						   description: {
 							  text: "단일 연결 리스트는 각 노드에 자료 공간과 한 개의 포인터 공간이 있고, 각 노드의 포인터는 다음 노드를 가리킨다.",
 							  links: [
-								 ["단일 연결 리스트 - 위키 트리", "https://ko.wikipedia.org/wiki/%EC%97%B0%EA%B2%B0_%EB%A6%AC%EC%8A%A4%ED%8A%B8"],
+								 ["단일 연결 리스트 - 위키백과", "https://ko.wikipedia.org/wiki/%EC%97%B0%EA%B2%B0_%EB%A6%AC%EC%8A%A4%ED%8A%B8"],
 								]
 						   },
 						},
@@ -37,7 +37,7 @@ export const datastructureCollection = {
 						   description: {
 							  text: "이중 연결 리스트의 구조는 단일 연결 리스트와 비슷하지만, 포인터 공간이 두 개가 있고 각각의 포인터는 앞의 노드와 뒤의 노드를 가리킨다.",
 							  links: [
-								["이중 연결 리스트 - 위키 트리", "https://ko.wikipedia.org/wiki/%EC%97%B0%EA%B2%B0_%EB%A6%AC%EC%8A%A4%ED%8A%B8"],
+								["이중 연결 리스트 - 위키백과", "https://ko.wikipedia.org/wiki/%EC%97%B0%EA%B2%B0_%EB%A6%AC%EC%8A%A4%ED%8A%B8"],
 							   ]
 						   },
 						},
@@ -46,7 +46,7 @@ export const datastructureCollection = {
 							description: {
 							  text: "원형 연결 리스트는 일반적인 연결 리스트에 마지막 노드와 처음 노드를 연결시켜 원형으로 만든 구조이다.",
 							  links: [
-							   ["원형 연결 리스트 - 위키 트리", "https://ko.wikipedia.org/wiki/%EC%97%B0%EA%B2%B0_%EB%A6%AC%EC%8A%A4%ED%8A%B8"],
+							   ["원형 연결 리스트 - 위키백과", "https://ko.wikipedia.org/wiki/%EC%97%B0%EA%B2%B0_%EB%A6%AC%EC%8A%A4%ED%8A%B8"],
 							   ]
 							}
 						 }
@@ -58,7 +58,7 @@ export const datastructureCollection = {
 					description: {
 						text: "스택(stack)은 제한적으로 접근할 수 있는 나열 구조이다. 그 접근 방법은 언제나 목록의 끝에서만 일어난다. 끝먼저내기 목록(Pushdown list)이라고도 한다.",
 						links: [
-							["스택 - 위키트리", "https://ko.wikipedia.org/wiki/%EC%8A%A4%ED%83%9D"],
+							["스택 - 위키백과", "https://ko.wikipedia.org/wiki/%EC%8A%A4%ED%83%9D"],
 							["스택 기초 YOUTUBE", "https://youtu.be/DsZHDmth6Pc"],
 						]
 					}
@@ -69,7 +69,7 @@ export const datastructureCollection = {
 					description: {
 						text: "큐(queue)는 컴퓨터의 기본적인 자료 구조의 한가지로, 먼저 집어 넣은 데이터가 먼저 나오는 FIFO(First In First Out)구조로 저장하는 형식을 말한다.",
 						links: [
-							["큐 - 위키트리", "https://ko.wikipedia.org/wiki/%ED%81%90_(%EC%9E%90%EB%A3%8C_%EA%B5%AC%EC%A1%B0)"],
+							["큐 - 위키백과", "https://ko.wikipedia.org/wiki/%ED%81%90_(%EC%9E%90%EB%A3%8C_%EA%B5%AC%EC%A1%B0)"],
 						]
 					}
 				},
@@ -79,7 +79,7 @@ export const datastructureCollection = {
 					description: {
 						text: "데크(deque)는 양쪽 끝에서 삽입과 삭제가 모두 가능한 자료 구조의 한 형태이다.",
 						links: [
-							["데크 - 위키트리", "https://ko.wikipedia.org/wiki/%EB%8D%B1_(%EC%9E%90%EB%A3%8C_%EA%B5%AC%EC%A1%B0)"],
+							["데크 - 위키백과", "https://ko.wikipedia.org/wiki/%EB%8D%B1_(%EC%9E%90%EB%A3%8C_%EA%B5%AC%EC%A1%B0)"],
 						]
 					}
 				},
@@ -92,7 +92,7 @@ export const datastructureCollection = {
 
 		{
 			name: "심화",
-			skills: [
+			skills:[
 
 		    ]
 		},


### PR DESCRIPTION
### **간략한 작업 요약**
'자료구조'-'기초'에 블록의 링크 이름을 수정했습니다.

### **상세한 작업 내용**
* 위키트리 -> 위키백과

로 수정했습니다.

***
### **스크린샷**
![image](https://user-images.githubusercontent.com/50025713/131158351-9153a544-82d8-4d61-9f80-0797a29aa82c.png)