### PR TITLE
[수정] Share menu 수정 (#2)

### DIFF
--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -48,7 +48,6 @@ export async function openShare ({title, text, url}) {
 		["Copy", () => copyToClipboard(url)],
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
-		["LinkedIn", () => openShareUrl(`https://www.linkedin.com/shareArticle?mini=true&url=${safeUrl}&title=${safeTitle}&summary=${safeText}`)],
 		["Reddit", () => openShareUrl(`https://www.reddit.com/submit?url=${safeUrl}&title=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
 		["Hacker News", () => openShareUrl(`https://news.ycombinator.com/submitlink?u=${safeUrl}&t=${safeText}`)],

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -49,7 +49,6 @@ export async function openShare ({title, text, url}) {
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
-		["Одноклассники", () => openShareUrl(`https://connect.ok.ru/offer?url=${safeUrl}&title=${safeTitle}&imageUrl=${safeImg}`), "ok"],
 		["Mix", () => openShareUrl(`https://mix.com/add?url=${safeUrl}`)]
 	];
 

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -49,7 +49,6 @@ export async function openShare ({title, text, url}) {
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
-		["Tumblr", () => openShareUrl(`https://www.tumblr.com/widgets/share/tool/preview?url=${safeUrl}`)],
 		["Pinterest", () => openShareUrl(`https://www.pinterest.dk/pin/create/button/?url=${safeUrl}&description=${safeText}&media=${safeImg}`)],
 		["ВКонтакте", () => openShareUrl(`https://vk.com/share.php?url=${safeUrl}&title=${safeTitle}&description=${safeText}&image=${safeImg}`), "vk"],
 		["Одноклассники", () => openShareUrl(`https://connect.ok.ru/offer?url=${safeUrl}&title=${safeTitle}&imageUrl=${safeImg}`), "ok"],

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -49,8 +49,6 @@ export async function openShare ({title, text, url}) {
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
-		
-		["Blogger", () => openShareUrl(`https://www.blogger.com/blog-this.g?n=${safeTitle}&b=${encodeURIComponent(`${text}. Find it <a href="${url}">here</a>.<br/><br/><img width="400" src="${img}" />`)}`)],
 		["Tumblr", () => openShareUrl(`https://www.tumblr.com/widgets/share/tool/preview?url=${safeUrl}`)],
 		["Pinterest", () => openShareUrl(`https://www.pinterest.dk/pin/create/button/?url=${safeUrl}&description=${safeText}&media=${safeImg}`)],
 		["ВКонтакте", () => openShareUrl(`https://vk.com/share.php?url=${safeUrl}&title=${safeTitle}&description=${safeText}&image=${safeImg}`), "vk"],

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -48,8 +48,7 @@ export async function openShare ({title, text, url}) {
 		["Copy", () => copyToClipboard(url)],
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
-		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
-		["Mix", () => openShareUrl(`https://mix.com/add?url=${safeUrl}`)]
+		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)]
 	];
 
 	// https://www.pinterest.dk/pin/create/button/?url=https://andreasbm.github.io/web-skills&description=A%20visual%20overview%20blah%20blah&media=https://andreasbm.github.io/web-skills/www/og-image.jpg

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -49,7 +49,6 @@ export async function openShare ({title, text, url}) {
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
-		["Hacker News", () => openShareUrl(`https://news.ycombinator.com/submitlink?u=${safeUrl}&t=${safeText}`)],
 		["Blogger", () => openShareUrl(`https://www.blogger.com/blog-this.g?n=${safeTitle}&b=${encodeURIComponent(`${text}. Find it <a href="${url}">here</a>.<br/><br/><img width="400" src="${img}" />`)}`)],
 		["Tumblr", () => openShareUrl(`https://www.tumblr.com/widgets/share/tool/preview?url=${safeUrl}`)],
 		["Pinterest", () => openShareUrl(`https://www.pinterest.dk/pin/create/button/?url=${safeUrl}&description=${safeText}&media=${safeImg}`)],

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -49,7 +49,6 @@ export async function openShare ({title, text, url}) {
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
-		["ВКонтакте", () => openShareUrl(`https://vk.com/share.php?url=${safeUrl}&title=${safeTitle}&description=${safeText}&image=${safeImg}`), "vk"],
 		["Одноклассники", () => openShareUrl(`https://connect.ok.ru/offer?url=${safeUrl}&title=${safeTitle}&imageUrl=${safeImg}`), "ok"],
 		["Mix", () => openShareUrl(`https://mix.com/add?url=${safeUrl}`)]
 	];

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -49,6 +49,7 @@ export async function openShare ({title, text, url}) {
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
+		
 		["Blogger", () => openShareUrl(`https://www.blogger.com/blog-this.g?n=${safeTitle}&b=${encodeURIComponent(`${text}. Find it <a href="${url}">here</a>.<br/><br/><img width="400" src="${img}" />`)}`)],
 		["Tumblr", () => openShareUrl(`https://www.tumblr.com/widgets/share/tool/preview?url=${safeUrl}`)],
 		["Pinterest", () => openShareUrl(`https://www.pinterest.dk/pin/create/button/?url=${safeUrl}&description=${safeText}&media=${safeImg}`)],

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -48,7 +48,6 @@ export async function openShare ({title, text, url}) {
 		["Copy", () => copyToClipboard(url)],
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
-		["Reddit", () => openShareUrl(`https://www.reddit.com/submit?url=${safeUrl}&title=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
 		["Hacker News", () => openShareUrl(`https://news.ycombinator.com/submitlink?u=${safeUrl}&t=${safeText}`)],
 		["Blogger", () => openShareUrl(`https://www.blogger.com/blog-this.g?n=${safeTitle}&b=${encodeURIComponent(`${text}. Find it <a href="${url}">here</a>.<br/><br/><img width="400" src="${img}" />`)}`)],

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -46,7 +46,6 @@ export async function openShare ({title, text, url}) {
 
 	const shareOptions = [
 		["Copy", () => copyToClipboard(url)],
-		["WhatsApp", () => openShareUrl(`https://wa.me/?text=${encodeURIComponent(`${title}. ${text}. Find it here ${url}`)}`)],
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
 		["LinkedIn", () => openShareUrl(`https://www.linkedin.com/shareArticle?mini=true&url=${safeUrl}&title=${safeTitle}&summary=${safeText}`)],

--- a/src/util/open-share.js
+++ b/src/util/open-share.js
@@ -49,7 +49,6 @@ export async function openShare ({title, text, url}) {
 		["Facebook", () => openShareUrl(`https://www.facebook.com/sharer/sharer.php?u=${safeUrl}`)],
 		["Twitter", () => openShareUrl(`https://twitter.com/intent/tweet?&url=${safeUrl}&text=${safeText}`)],
 		["Email", () => openShareUrl(`mailto:?subject=${safeTitle}&body=${encodeURIComponent(`${text}. Find it here ${url}`)}`)],
-		["Pinterest", () => openShareUrl(`https://www.pinterest.dk/pin/create/button/?url=${safeUrl}&description=${safeText}&media=${safeImg}`)],
 		["ВКонтакте", () => openShareUrl(`https://vk.com/share.php?url=${safeUrl}&title=${safeTitle}&description=${safeText}&image=${safeImg}`), "vk"],
 		["Одноклассники", () => openShareUrl(`https://connect.ok.ru/offer?url=${safeUrl}&title=${safeTitle}&imageUrl=${safeImg}`), "ok"],
 		["Mix", () => openShareUrl(`https://mix.com/add?url=${safeUrl}`)]


### PR DESCRIPTION
### **간략한 작업 요약**
share menu에 copy, twitter, facebook, email만 남겼습니다.

### **상세한 작업 내용**
* WhatsApp
* LinkedIn
* Reddit
* Hacker News
* Blogger
* Tumblr
* Pinterest
* ВКонтакте
* Одноклассники
* Mix

를 삭제했습니다.

***
### **스크린샷**
![image](https://user-images.githubusercontent.com/48914876/131616380-4327cad8-18a0-4e1f-b79f-0a4d0f76ba1c.png)

***
### **리뷰어들이 꼭 체크해야 하는 것**
- [x] 내용 중 오타가 있는지 확인했나요?
- [x] 알맞은 이슈와 연결되어 있나요?
- [x] 이슈의 기능이 구현되었나요?/버그가 해결되었나요?
- [x] 커밋메세지가 바르게 올라왔나요?


