### PR TITLE
[리드미 추가] 코딩 테스트 추가 (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ Reach out to me on Twitter at [@AndreasMehlsen](https://twitter.com/AndreasMehls
 
 ## ➤ 코딩 테스트
 ## 해외
-<!-- ⚠️ 코딩 테스트 - 소분류 추가 예정 ⚠️-->
+### 코드포스
+경쟁적 프로그래밍 대회를 주기적으로 개최하는 사이트이다.
+* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://codeforces.com/" alt="Logo" />codeforces](https://codeforces.com/)
+
 
 ## 국내
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Reach out to me on Twitter at [@AndreasMehlsen](https://twitter.com/AndreasMehls
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#코딩-테스트)
 
 ## ➤ 코딩 테스트
-
+## 해외
 <!-- ⚠️ 코딩 테스트 - 소분류 추가 예정 ⚠️-->
 
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Topcoder 커뮤니티의 경쟁 프로그래밍 트랙은 단일 라운드 매�
 
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://programmers.co.kr/" alt="Logo" />프로그래머스](https://programmers.co.kr/)
 
+### 코드업
+
+정보과학 의 기초, 심화 및 한국정보올림피아드 대비 등의 정보과학 예제를 풀어볼 수 있는 알고리즘 트레이닝 사이트이다.
+
+* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://codeup.kr/" alt="Logo" />코드업](https://codeup.kr/)
+
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#contributors)
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Topcoder 커뮤니티의 경쟁 프로그래밍 트랙은 단일 라운드 매�
 
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://codeup.kr/" alt="Logo" />코드업](https://codeup.kr/)
 
+### SW Expert Academy
+
+알고리즘 테스트 및 프로그래밍 역량 강화를 위한 학습 컨텐츠를 제공하는 삼성에서 만든 사이트이다.
+
+* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://swexpertacademy.com/main/main.do" alt="Logo" />SW Expert Academy](https://swexpertacademy.com/main/main.do)
+
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#contributors)
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Reach out to me on Twitter at [@AndreasMehlsen](https://twitter.com/AndreasMehls
 ## 해외
 <!-- ⚠️ 코딩 테스트 - 소분류 추가 예정 ⚠️-->
 
-
+## 국내
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#contributors)
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Topcoder 커뮤니티의 경쟁 프로그래밍 트랙은 단일 라운드 매�
 
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://www.acmicpc.net/" alt="Logo" />백준](https://www.acmicpc.net/)
 
+### 프로그래머스
+
+코드 중심의 개발자 채용 및 코딩테스트 결과를 분석해 만든 알고리즘/자료구조 문제를 제공하는 사이트이다.
+
+* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://programmers.co.kr/" alt="Logo" />프로그래머스](https://programmers.co.kr/)
+
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#contributors)
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ Topcoder 커뮤니티의 경쟁 프로그래밍 트랙은 단일 라운드 매�
 
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://www.topcoder.com/" alt="Logo" />topcoder](https://www.topcoder.com/)
 
+### 코드셰프
+
+전 세계 프로그래머로 구성된 경쟁력있는 프로그래밍 커뮤니티이다.
+
+* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://www.codechef.com/" alt="Logo" />codechef](https://www.codechef.com/)
 ## 국내
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#contributors)

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Topcoder 커뮤니티의 경쟁 프로그래밍 트랙은 단일 라운드 매�
 전 세계 프로그래머로 구성된 경쟁력있는 프로그래밍 커뮤니티이다.
 
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://www.codechef.com/" alt="Logo" />codechef](https://www.codechef.com/)
+
+### 릿코드
+
+기술을 향상하고 지식을 확장하며 기술 면접을 준비하는 데 도움이 되는 플랫폼이다.
+
+* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://leetcode.com/" alt="Logo" />leetcode](https://leetcode.com/)
 ## 국내
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#contributors)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ Topcoder 커뮤니티의 경쟁 프로그래밍 트랙은 단일 라운드 매�
 기술을 향상하고 지식을 확장하며 기술 면접을 준비하는 데 도움이 되는 플랫폼이다.
 
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://leetcode.com/" alt="Logo" />leetcode](https://leetcode.com/)
+
 ## 국내
+
+### 백준
+
+백준 온라인 저지는 컴퓨터 프로그래밍 알고리즘 문제 풀이 서비스를 제공해주는 웹사이트이다.
+
+* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://www.acmicpc.net/" alt="Logo" />백준](https://www.acmicpc.net/)
+
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#contributors)
 

--- a/README.md
+++ b/README.md
@@ -107,11 +107,20 @@ Reach out to me on Twitter at [@AndreasMehlsen](https://twitter.com/AndreasMehls
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#코딩-테스트)
 
 ## ➤ 코딩 테스트
+
 ## 해외
+
 ### 코드포스
+
 경쟁적 프로그래밍 대회를 주기적으로 개최하는 사이트이다.
+
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://codeforces.com/" alt="Logo" />codeforces](https://codeforces.com/)
 
+### 탑코더
+
+Topcoder 커뮤니티의 경쟁 프로그래밍 트랙은 단일 라운드 매치(SRM)를 중심으로 순환하며, 모든 참가자가 가능한 한 빨리 동일한 문제 세트를 해결하기 위해 온라인에서 경쟁하는 1.5시간짜리 대회이다.
+
+* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https://www.topcoder.com/" alt="Logo" />topcoder](https://www.topcoder.com/)
 
 ## 국내
 


### PR DESCRIPTION
### **간략한 작업 요약**
 '코딩 테스트' 중분류, 소분류를 추가했습니다.

### **상세한 작업 내용**
* 해외
    *  코드포스
    * 탑코더
    * 코드셰프
    * 릿코드
* 국내
    * 백준
    * 프로그래머스
    * 코드업
    * SW Expert Academy

를 추가했습니다.

***
### **스크린샷**
![image](https://user-images.githubusercontent.com/48914876/131977951-52b1041a-6e8f-4211-ba81-c96985c4ceb0.png)
![image](https://user-images.githubusercontent.com/48914876/131977993-66902447-7b98-4e21-8ac9-b7c1bd940d7a.png)


***
### **리뷰어들이 꼭 체크해야 하는 것**
- [x] 내용 중 오타가 있는지 확인했나요?
- [x] 알맞은 이슈와 연결되어 있나요?
- [x] 이슈의 기능이 구현되었나요?/버그가 해결되었나요?
- [x] 커밋메세지가 바르게 올라왔나요?
- [x] `feature/#47-{이름}`브랜치가 base 브랜치인 `feature/#47`로 병합되도록 해놨나요?